### PR TITLE
Fix MACD selection and SQL queries

### DIFF
--- a/backtester/db.py
+++ b/backtester/db.py
@@ -9,8 +9,8 @@ def get_connection(host="localhost", user="root", password="root", database="sct
 
 def load_candles(conn, table, symbol, start, end):
     query = (
-        f"SELECT startTime, openPrice, highPrice, lowPrice, closePrice, volume, turnover "
-        f"FROM {table} WHERE symbol=%s AND startTime >= %s AND startTime <= %s ORDER BY startTime"
+        f"SELECT symbol, startTime, openPrice, highPrice, lowPrice, closePrice, volume, turnover "
+        f"FROM {table} WHERE symbol = %s AND startTime BETWEEN %s AND %s ORDER BY startTime"
     )
     df = pd.read_sql(query, conn, params=(symbol, start, end))
     df['startTime'] = pd.to_datetime(df['startTime'])

--- a/backtester/engine.py
+++ b/backtester/engine.py
@@ -14,8 +14,12 @@ def backtest(df5, df1, params):
     macd_full = macd(df1['closePrice'], params['macd_fast'], params['macd_slow'], params['macd_signal'])
     df1 = df1.copy()
     df1[['macd', 'signal', 'hist']] = macd_full
-    macd_sel = df1.groupby(df1['startTime'].dt.floor('5min')).apply(lambda x: x.loc[x['hist'].abs().idxmax()])
-    macd_sel = macd_sel.sort_values('startTime')
+    macd_sel = (
+        df1.groupby(df1['startTime'].dt.floor('5min'))
+        .apply(lambda x: x.loc[x['hist'].abs().idxmax()])
+        .reset_index(drop=True)
+        .sort_values('startTime')
+    )
     macd_sel['avg'] = macd_sel['hist'].rolling(72).mean()
     macd_map = macd_sel.set_index('startTime')
 


### PR DESCRIPTION
## Summary
- fix MACD candle selection to avoid index ambiguity
- include `symbol` column in candle SQL selects

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python backtest.py --symbol BTCUSDT --from "2024-06-09 00:00" --to "2024-06-16 00:00"` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68503312bb108329a258e03638b88e98